### PR TITLE
feat: add support for postcode/zipcode geocoding lookup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,10 +115,16 @@ The architecture uses a layered approach separating hardware abstraction (**Scre
 
 **[weather.py](weather.py)** - Weather API integration and caching
 - Fetches from OpenWeather OneCall API 3.0 (returns current + daily forecast)
-- `lookup_geocoding()` converts zip/postcode and country code to lat/lon using OpenWeather Geocoding API
 - Implements file-based caching in `cache/` directory with timestamp validation
 - `Weather` and `Temperature` are simple data classes (no `@dataclass`, manual serialization)
 - Maps weather condition titles to icon names
+
+**[geocoding.py](geocoding.py)** - Geocoding API integration and caching
+- `lookup_geocoding()` converts zip/postcode and country code to lat/lon using OpenWeather Geocoding API
+- Implements file-based caching in `cache/` directory (cache key: `{zip}_{country}`)
+- `GeocodingResult` data class stores zip, country, location name, lat, and lon
+- Cache functions: `load_cached_geocoding()`, `cache_geocoding()`, `is_geocoding_cache_valid()`
+- `fetch_geocoding()` performs the actual API call (called by `lookup_geocoding()` on cache miss)
 
 **[net.py](net.py)** - WiFi connection management
 - Simple connect/disconnect functions for `network.WLAN`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,10 +121,11 @@ The architecture uses a layered approach separating hardware abstraction (**Scre
 
 **[geocoding.py](geocoding.py)** - Geocoding API integration and caching
 - `lookup_geocoding()` converts zip/postcode and country code to lat/lon using OpenWeather Geocoding API
-- Implements file-based caching in `cache/` directory (cache key: `{zip}_{country}`)
+- Implements permanent file-based caching in `cache/` directory (cache key: `{zip}_{country}`, no expiry)
 - `GeocodingResult` data class stores zip, country, location name, lat, and lon
 - Cache functions: `load_cached_geocoding()`, `cache_geocoding()`, `is_geocoding_cache_valid()`
 - `fetch_geocoding()` performs the actual API call (called by `lookup_geocoding()` on cache miss)
+- Geocoding results are cached permanently since they don't change over time
 
 **[net.py](net.py)** - WiFi connection management
 - Simple connect/disconnect functions for `network.WLAN`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,10 @@ Exit REPL with `Ctrl-]`
 
 ### Setup
 
-1. Copy `config.txt.example` to `config.txt` and fill in WiFi credentials, location coordinates, and OpenWeather API key
+1. Copy `config.txt.example` to `config.txt` and fill in:
+   - WiFi credentials
+   - Location (either lat/lon coordinates OR zip/postcode and country code)
+   - OpenWeather API key
 2. Ensure MicroPython is installed on the Pico W (firmware files included in repo: `RPI_PICO2_W-20251209-v1.27.0.uf2` and `RPI_PICO_W-20231227-v1.22.0.uf2`)
 
 ## Architecture
@@ -112,6 +115,7 @@ The architecture uses a layered approach separating hardware abstraction (**Scre
 
 **[weather.py](weather.py)** - Weather API integration and caching
 - Fetches from OpenWeather OneCall API 3.0 (returns current + daily forecast)
+- `lookup_geocoding()` converts zip/postcode and country code to lat/lon using OpenWeather Geocoding API
 - Implements file-based caching in `cache/` directory with timestamp validation
 - `Weather` and `Temperature` are simple data classes (no `@dataclass`, manual serialization)
 - Maps weather condition titles to icon names
@@ -137,7 +141,7 @@ The architecture uses a layered approach separating hardware abstraction (**Scre
 ### Data Flow
 
 1. **Initialization**: `read_config()` → `get_epd()` creates `Screen` → wrap in `PaddedScreen` (if configured) → wrap in `BufferedScreen` → `get_font_renderer()` → create `DisplayController`
-2. **Fetch phase**: Check cache → connect to WiFi if needed → call OpenWeather API → parse JSON → disconnect → cache results
+2. **Fetch phase**: Check cache → connect to WiFi if needed → lookup geocoding (if zip/country specified) → call OpenWeather API → parse JSON → disconnect → cache results
 3. **Render phase**: Enable virtual mode → `render()` uses `DisplayController` with render flags → `FontRenderer` renders text → disable virtual mode to flush buffered operations
 4. **Sleep phase**: Deep sleep the display → sleep CPU for `refresh_mins` → loop
 
@@ -145,7 +149,9 @@ The architecture uses a layered approach separating hardware abstraction (**Scre
 
 `config.txt` structure (key=value format):
 - `ssid`, `password` - WiFi credentials
-- `lat`, `lon` - Location coordinates for weather
+- **Location** (specify EITHER lat/lon OR zip/country):
+  - `lat`, `lon` - Direct location coordinates for weather
+  - `zip`, `country` - Zip/postcode and country code (e.g., `zip=E14`, `country=GB`). Automatically geocoded to lat/lon using OpenWeather Geocoding API
 - `openweathermap_key` - API key
 - `refresh_mins` - Main loop sleep duration (how often to update weather)
 - `cache_mins` - How long cached API responses stay valid (reduces API calls)

--- a/config.py
+++ b/config.py
@@ -26,37 +26,45 @@ def read_config() -> Config:
     config.padding = None
     config.text_renderer = 'basic'
 
+    # Supported configuration keys
+    supported_keys = [
+        'ssid',
+        'password',
+        'lat',
+        'lon',
+        'zip',
+        'country',
+        'openweathermap_key',
+        'refresh_mins',
+        'cache_mins',
+        'display_size',
+        'padding',
+        'text_renderer'
+    ]
+
     with open('config.txt') as f:
         for line in f:
             if line.startswith('#'):
                 # ignore comments
                 continue
-            elif line.startswith('ssid='):
-                config.ssid = line[5:].strip()
-            elif line.startswith('password='):
-                config.password = line[9:].strip()
-            elif line.startswith('lat='):
-                config.lat = line[4:].strip()
-            elif line.startswith('lon='):
-                config.lon = line[4:].strip()
-            elif line.startswith('zip='):
-                config.zip = line[4:].strip()
-            elif line.startswith('country='):
-                config.country = line[8:].strip()
-            elif line.startswith('openweathermap_key='):
-                config.openweathermap_key = line[19:].strip()
-            elif line.startswith('refresh_mins='):
-                config.refresh_mins = int(line[13:].strip())
-            elif line.startswith('cache_mins='):
-                config.cache_mins = int(line[11:].strip())
-            elif line.startswith('display_size='):
-                config.display_size = line[13:].strip()
-            elif line.startswith('padding='):
-                padding_str = line[8:].strip()
-                parts = padding_str.split(',')
-                if len(parts) == 4:
-                    config.padding = (int(parts[0]), int(parts[1]), int(parts[2]), int(parts[3]))
-            elif line.startswith('text_renderer='):
-                config.text_renderer = line[14:].strip()
+
+            # Check each supported key
+            for key in supported_keys:
+                key_prefix = key + '='
+                if line.startswith(key_prefix):
+                    # Calculate offset: key length + equals sign
+                    offset = len(key) + 1
+                    value = line[offset:].strip()
+
+                    # Handle special cases for type conversion and parsing
+                    if key == 'refresh_mins' or key == 'cache_mins':
+                        setattr(config, key, int(value))
+                    elif key == 'padding':
+                        parts = value.split(',')
+                        if len(parts) == 4:
+                            config.padding = (int(parts[0]), int(parts[1]), int(parts[2]), int(parts[3]))
+                    else:
+                        setattr(config, key, value)
+                    break
 
     return config

--- a/config.py
+++ b/config.py
@@ -1,8 +1,10 @@
 class Config:
     ssid: str
     password: str
-    lat: str
-    lon: str
+    lat: str | None
+    lon: str | None
+    zip: str | None
+    country: str | None
     openweathermap_key: str
     refresh_mins: int
     cache_mins: int
@@ -17,6 +19,10 @@ def read_config() -> Config:
     :return: the configuration
     """
     config = Config()
+    config.lat = None
+    config.lon = None
+    config.zip = None
+    config.country = None
     config.padding = None
     config.text_renderer = 'basic'
 
@@ -33,6 +39,10 @@ def read_config() -> Config:
                 config.lat = line[4:].strip()
             elif line.startswith('lon='):
                 config.lon = line[4:].strip()
+            elif line.startswith('zip='):
+                config.zip = line[4:].strip()
+            elif line.startswith('country='):
+                config.country = line[8:].strip()
             elif line.startswith('openweathermap_key='):
                 config.openweathermap_key = line[19:].strip()
             elif line.startswith('refresh_mins='):

--- a/config.txt.example
+++ b/config.txt.example
@@ -2,9 +2,15 @@
 ssid=yourssid
 password=yourpassword
 
-# Your location in lat/lon
+# Your location - specify EITHER lat/lon OR zip/country
+# Option 1: Direct coordinates
 lat=50.819767
 lon=3.257726
+
+# Option 2: Zip/postcode and country code (will be geocoded automatically)
+# Uncomment these and comment out lat/lon to use zip-based lookup
+# zip=E14
+# country=GB
 
 # API key for openweathermap
 openweathermap_key=yourapikey

--- a/geocoding.py
+++ b/geocoding.py
@@ -1,0 +1,178 @@
+import urequests as requests
+import json
+import os
+import utime
+
+from utils import dir_exists, file_exists
+
+
+CACHE_DIR = 'cache'
+
+
+class GeocodingResult:
+    """Represents a geocoding lookup result"""
+    zip: str
+    country: str
+    name: str
+    lat: str
+    lon: str
+
+    def __init__(self, zip_code: str, country: str, name: str, lat: str, lon: str):
+        self.zip = zip_code
+        self.country = country
+        self.name = name
+        self.lat = lat
+        self.lon = lon
+
+    def to_dict(self):
+        return {
+            'zip': self.zip,
+            'country': self.country,
+            'name': self.name,
+            'lat': self.lat,
+            'lon': self.lon,
+        }
+
+    @classmethod
+    def from_dict(cls, data):
+        return cls(data['zip'], data['country'], data['name'], data['lat'], data['lon'])
+
+
+def get_cache_key(zip_code: str, country: str) -> str:
+    """
+    Returns a cache key for the given zip/postcode and country
+    :param zip_code: the zip/postcode
+    :param country: the country code
+    :return: the cache key
+    """
+    return f"{zip_code}_{country}"
+
+
+def ensure_cache_dir():
+    """
+    Ensures that the cache directory exists.
+    """
+    if not dir_exists(CACHE_DIR):
+        os.mkdir(CACHE_DIR)
+
+
+def is_geocoding_cache_valid(zip_code: str, country: str, cache_mins: int) -> bool:
+    """
+    Checks if the cached geocoding result is still valid
+    :param zip_code: the zip/postcode
+    :param country: the country code
+    :param cache_mins: the cache expiry in minutes
+    :return: True if cache is valid, False otherwise
+    """
+    ensure_cache_dir()
+    cache_key = get_cache_key(zip_code, country)
+
+    is_valid: bool
+    timestamp_file = f'{CACHE_DIR}/geocoding_{cache_key}_timestamp'
+    if file_exists(timestamp_file):
+        with open(timestamp_file, 'r') as f:
+            timestamp = int(f.read())
+            age = utime.time() - timestamp
+            print(f"geocoding cache for {cache_key} is {age} seconds old")
+
+            # if age is negative, the device RTC is probably not set
+            is_valid = 0 <= age < (cache_mins * 60)
+
+    else:
+        is_valid = False
+
+    print(f"geocoding cache for {cache_key} is {'valid' if is_valid else 'invalid'} (expiry {cache_mins} mins)")
+    return is_valid
+
+
+def cache_geocoding(result: GeocodingResult, cache_mins: int):
+    """
+    Caches the geocoding result
+    :param result: the geocoding result
+    :param cache_mins: the cache expiry in minutes (used for logging only)
+    """
+    ensure_cache_dir()
+    cache_key = get_cache_key(result.zip, result.country)
+    print(f"caching geocoding result for {cache_key} (expiry {cache_mins} mins)")
+
+    with open(f'{CACHE_DIR}/geocoding_{cache_key}.json', 'w') as f:
+        result_json = json.dumps(result.to_dict())
+        f.write(result_json)
+
+    with open(f'{CACHE_DIR}/geocoding_{cache_key}_timestamp', 'w') as f:
+        f.write(str(utime.time()))
+
+
+def load_cached_geocoding(zip_code: str, country: str, cache_mins: int) -> GeocodingResult | None:
+    """
+    Loads the cached geocoding result if it exists and is valid
+    :param zip_code: the zip/postcode
+    :param country: the country code
+    :param cache_mins: the cache expiry in minutes
+    :return: the cached geocoding result, or None if not found or invalid
+    """
+    if not is_geocoding_cache_valid(zip_code, country, cache_mins):
+        return None
+
+    ensure_cache_dir()
+    cache_key = get_cache_key(zip_code, country)
+    cache_file = f'{CACHE_DIR}/geocoding_{cache_key}.json'
+
+    if file_exists(cache_file):
+        with open(cache_file, 'r') as f:
+            result_json = f.read()
+            print(f"loaded cached geocoding for {cache_key}: {result_json}")
+            result_dict = json.loads(result_json)
+            return GeocodingResult.from_dict(result_dict)
+    else:
+        print(f"geocoding cache for {cache_key} does not exist")
+        return None
+
+
+def fetch_geocoding(zip_code: str, country: str, openweathermap_key: str) -> GeocodingResult:
+    """
+    Fetches geocoding data from OpenWeatherMap API (no caching)
+    :param zip_code: the zip/postcode
+    :param country: the country code (e.g. 'GB', 'US')
+    :param openweathermap_key: the OpenWeatherMap API key
+    :return: the geocoding result
+    """
+    url = f"http://api.openweathermap.org/geo/1.0/zip?zip={zip_code},{country}&appid={openweathermap_key}"
+    print(f"geocoding API lookup: {url}")
+    r = requests.get(url)
+    resp: dict = r.json()
+    r.close()
+
+    lat = str(resp['lat'])
+    lon = str(resp['lon'])
+    name = resp['name']
+
+    print(f"geocoding result: {name} ({resp['country']}) -> lat={lat}, lon={lon}")
+
+    return GeocodingResult(zip_code, country, name, lat, lon)
+
+
+def lookup_geocoding(zip_code: str, country: str, openweathermap_key: str, cache_mins: int) -> tuple[str, str]:
+    """
+    Looks up the latitude and longitude for a given zip/postcode and country code.
+    First checks the cache, then calls the API if needed.
+    :param zip_code: the zip/postcode
+    :param country: the country code (e.g. 'GB', 'US')
+    :param openweathermap_key: the OpenWeatherMap API key
+    :param cache_mins: the cache expiry in minutes
+    :return: tuple of (lat, lon) as strings
+    """
+    # Try to load from cache first
+    cached = load_cached_geocoding(zip_code, country, cache_mins)
+    if cached is not None:
+        print(f"using cached geocoding: {cached.name} -> lat={cached.lat}, lon={cached.lon}")
+        return cached.lat, cached.lon
+
+    # Cache miss - fetch from API
+    print(f"no cached geocoding found; fetching from API")
+    result = fetch_geocoding(zip_code, country, openweathermap_key)
+
+    # Cache the result
+    cache_geocoding(result, cache_mins)
+
+    return result.lat, result.lon

--- a/geocoding.py
+++ b/geocoding.py
@@ -1,7 +1,6 @@
 import urequests as requests
 import json
 import os
-import utime
 
 from utils import dir_exists, file_exists
 
@@ -56,77 +55,54 @@ def ensure_cache_dir():
         os.mkdir(CACHE_DIR)
 
 
-def is_geocoding_cache_valid(zip_code: str, country: str, cache_mins: int) -> bool:
+def is_geocoding_cache_valid(zip_code: str, country: str) -> bool:
     """
-    Checks if the cached geocoding result is still valid
+    Checks if the cached geocoding result exists
     :param zip_code: the zip/postcode
     :param country: the country code
-    :param cache_mins: the cache expiry in minutes
-    :return: True if cache is valid, False otherwise
+    :return: True if cache exists, False otherwise
     """
     ensure_cache_dir()
     cache_key = get_cache_key(zip_code, country)
+    cache_file = f'{CACHE_DIR}/geocoding_{cache_key}.json'
 
-    is_valid: bool
-    timestamp_file = f'{CACHE_DIR}/geocoding_{cache_key}_timestamp'
-    if file_exists(timestamp_file):
-        with open(timestamp_file, 'r') as f:
-            timestamp = int(f.read())
-            age = utime.time() - timestamp
-            print(f"geocoding cache for {cache_key} is {age} seconds old")
-
-            # if age is negative, the device RTC is probably not set
-            is_valid = 0 <= age < (cache_mins * 60)
-
-    else:
-        is_valid = False
-
-    print(f"geocoding cache for {cache_key} is {'valid' if is_valid else 'invalid'} (expiry {cache_mins} mins)")
+    is_valid = file_exists(cache_file)
+    print(f"geocoding cache for {cache_key} {'exists' if is_valid else 'does not exist'}")
     return is_valid
 
 
-def cache_geocoding(result: GeocodingResult, cache_mins: int):
+def cache_geocoding(result: GeocodingResult):
     """
-    Caches the geocoding result
+    Caches the geocoding result permanently (no expiry)
     :param result: the geocoding result
-    :param cache_mins: the cache expiry in minutes (used for logging only)
     """
     ensure_cache_dir()
     cache_key = get_cache_key(result.zip, result.country)
-    print(f"caching geocoding result for {cache_key} (expiry {cache_mins} mins)")
+    print(f"caching geocoding result for {cache_key}")
 
     with open(f'{CACHE_DIR}/geocoding_{cache_key}.json', 'w') as f:
         result_json = json.dumps(result.to_dict())
         f.write(result_json)
 
-    with open(f'{CACHE_DIR}/geocoding_{cache_key}_timestamp', 'w') as f:
-        f.write(str(utime.time()))
 
-
-def load_cached_geocoding(zip_code: str, country: str, cache_mins: int) -> GeocodingResult | None:
+def load_cached_geocoding(zip_code: str, country: str) -> GeocodingResult | None:
     """
-    Loads the cached geocoding result if it exists and is valid
+    Loads the cached geocoding result if it exists
     :param zip_code: the zip/postcode
     :param country: the country code
-    :param cache_mins: the cache expiry in minutes
-    :return: the cached geocoding result, or None if not found or invalid
+    :return: the cached geocoding result, or None if not found
     """
-    if not is_geocoding_cache_valid(zip_code, country, cache_mins):
+    if not is_geocoding_cache_valid(zip_code, country):
         return None
 
-    ensure_cache_dir()
     cache_key = get_cache_key(zip_code, country)
     cache_file = f'{CACHE_DIR}/geocoding_{cache_key}.json'
 
-    if file_exists(cache_file):
-        with open(cache_file, 'r') as f:
-            result_json = f.read()
-            print(f"loaded cached geocoding for {cache_key}: {result_json}")
-            result_dict = json.loads(result_json)
-            return GeocodingResult.from_dict(result_dict)
-    else:
-        print(f"geocoding cache for {cache_key} does not exist")
-        return None
+    with open(cache_file, 'r') as f:
+        result_json = f.read()
+        print(f"loaded cached geocoding for {cache_key}: {result_json}")
+        result_dict = json.loads(result_json)
+        return GeocodingResult.from_dict(result_dict)
 
 
 def fetch_geocoding(zip_code: str, country: str, openweathermap_key: str) -> GeocodingResult:
@@ -152,18 +128,17 @@ def fetch_geocoding(zip_code: str, country: str, openweathermap_key: str) -> Geo
     return GeocodingResult(zip_code, country, name, lat, lon)
 
 
-def lookup_geocoding(zip_code: str, country: str, openweathermap_key: str, cache_mins: int) -> tuple[str, str]:
+def lookup_geocoding(zip_code: str, country: str, openweathermap_key: str) -> tuple[str, str]:
     """
     Looks up the latitude and longitude for a given zip/postcode and country code.
-    First checks the cache, then calls the API if needed.
+    First checks the cache, then calls the API if needed. Results are cached permanently.
     :param zip_code: the zip/postcode
     :param country: the country code (e.g. 'GB', 'US')
     :param openweathermap_key: the OpenWeatherMap API key
-    :param cache_mins: the cache expiry in minutes
     :return: tuple of (lat, lon) as strings
     """
     # Try to load from cache first
-    cached = load_cached_geocoding(zip_code, country, cache_mins)
+    cached = load_cached_geocoding(zip_code, country)
     if cached is not None:
         print(f"using cached geocoding: {cached.name} -> lat={cached.lat}, lon={cached.lon}")
         return cached.lat, cached.lon
@@ -172,7 +147,7 @@ def lookup_geocoding(zip_code: str, country: str, openweathermap_key: str, cache
     print(f"no cached geocoding found; fetching from API")
     result = fetch_geocoding(zip_code, country, openweathermap_key)
 
-    # Cache the result
-    cache_geocoding(result, cache_mins)
+    # Cache the result permanently
+    cache_geocoding(result)
 
     return result.lat, result.lon

--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ from net import connect_to_network, disconnect
 from display import DisplayController
 from config import read_config
 from weather import Weather, load_cached_weather, fetch_weather, \
-    cache_weather
+    cache_weather, lookup_geocoding
 
 
 def fetch(config: Config, display: DisplayController) -> tuple[Weather, Weather]:
@@ -49,8 +49,48 @@ def fetch(config: Config, display: DisplayController) -> tuple[Weather, Weather]
         f"IP: {ip}"
     )
 
+    # Determine lat/lon - either from config or via geocoding lookup
+    lat = config.lat
+    lon = config.lon
+
+    if lat is None or lon is None:
+        if config.zip is not None and config.country is not None:
+            print(f"performing geocoding lookup for {config.zip}, {config.country}")
+            display.display_text(
+                DisplayController.RENDER_FLAG_FLUSH,
+                FontSize.SMALL,
+                f"Looking up location..."
+            )
+            try:
+                lat, lon = lookup_geocoding(config.zip, config.country, config.openweathermap_key)
+            except Exception as e:
+                print(f"error during geocoding lookup: {e}")
+                display.display_text(
+                    DisplayController.RENDER_FLAG_FLUSH,
+                    FontSize.SMALL,
+                    "Failed to lookup location",
+                    f"Cause: {e}"
+                )
+                display.deep_sleep()
+                disconnect(wlan)
+                utime.sleep(300)
+                machine.reset()
+        else:
+            print(f"error: must specify either lat/lon or zip/country in config.txt")
+            display.display_text(
+                DisplayController.RENDER_FLAG_FLUSH,
+                FontSize.SMALL,
+                "Config error:",
+                "Must specify lat/lon",
+                "or zip/country"
+            )
+            display.deep_sleep()
+            disconnect(wlan)
+            utime.sleep(300)
+            machine.reset()
+
     try:
-        current, daily = fetch_weather(display, config.lat, config.lon, config.openweathermap_key)
+        current, daily = fetch_weather(display, lat, lon, config.openweathermap_key)
     except Exception as e:
         print(f"error fetching weather: {e}")
         display.display_text(

--- a/main.py
+++ b/main.py
@@ -63,7 +63,7 @@ def fetch(config: Config, display: DisplayController) -> tuple[Weather, Weather]
                 f"Looking up location..."
             )
             try:
-                lat, lon = lookup_geocoding(config.zip, config.country, config.openweathermap_key, config.cache_mins)
+                lat, lon = lookup_geocoding(config.zip, config.country, config.openweathermap_key)
             except Exception as e:
                 print(f"error during geocoding lookup: {e}")
                 display.display_text(

--- a/main.py
+++ b/main.py
@@ -10,7 +10,8 @@ from net import connect_to_network, disconnect
 from display import DisplayController
 from config import read_config
 from weather import Weather, load_cached_weather, fetch_weather, \
-    cache_weather, lookup_geocoding
+    cache_weather
+from geocoding import lookup_geocoding
 
 
 def fetch(config: Config, display: DisplayController) -> tuple[Weather, Weather]:
@@ -62,7 +63,7 @@ def fetch(config: Config, display: DisplayController) -> tuple[Weather, Weather]
                 f"Looking up location..."
             )
             try:
-                lat, lon = lookup_geocoding(config.zip, config.country, config.openweathermap_key)
+                lat, lon = lookup_geocoding(config.zip, config.country, config.openweathermap_key, config.cache_mins)
             except Exception as e:
                 print(f"error during geocoding lookup: {e}")
                 display.display_text(

--- a/main.py
+++ b/main.py
@@ -14,6 +14,60 @@ from weather import Weather, load_cached_weather, fetch_weather, \
 from geocoding import lookup_geocoding
 
 
+def determine_location(config: Config, display: DisplayController, wlan) -> tuple[str, str]:
+    """
+    Determines the latitude and longitude from config (either direct lat/lon or via geocoding).
+    If unable to determine location, displays error and resets the device.
+    :param config: the configuration
+    :param display: the display controller
+    :param wlan: the network connection (used for cleanup on error)
+    :return: tuple of (lat, lon) as strings
+    """
+    # Check if lat/lon are directly specified in config
+    lat = config.lat
+    lon = config.lon
+
+    if lat is None or lon is None:
+        if config.zip is not None and config.country is not None:
+            # Perform geocoding lookup
+            print(f"performing geocoding lookup for {config.zip}, {config.country}")
+            display.display_text(
+                DisplayController.RENDER_FLAG_FLUSH,
+                FontSize.SMALL,
+                f"Looking up location..."
+            )
+            try:
+                lat, lon = lookup_geocoding(config.zip, config.country, config.openweathermap_key)
+            except Exception as e:
+                print(f"error during geocoding lookup: {e}")
+                display.display_text(
+                    DisplayController.RENDER_FLAG_FLUSH,
+                    FontSize.SMALL,
+                    "Failed to lookup location",
+                    f"Cause: {e}"
+                )
+                display.deep_sleep()
+                disconnect(wlan)
+                utime.sleep(300)
+                machine.reset()
+        else:
+            # Neither lat/lon nor zip/country specified
+            print(f"error: must specify either lat/lon or zip/country in config.txt")
+            display.display_text(
+                DisplayController.RENDER_FLAG_FLUSH,
+                FontSize.SMALL,
+                "Config error:",
+                "Must specify lat/lon",
+                "or zip/country"
+            )
+            display.deep_sleep()
+            disconnect(wlan)
+            utime.sleep(300)
+            machine.reset()
+
+    return lat, lon
+
+
 def fetch(config: Config, display: DisplayController) -> tuple[Weather, Weather]:
     """
     First tries to load the weather from the cache. If it's not there, connects to the configured network, fetches the
@@ -51,44 +105,7 @@ def fetch(config: Config, display: DisplayController) -> tuple[Weather, Weather]
     )
 
     # Determine lat/lon - either from config or via geocoding lookup
-    lat = config.lat
-    lon = config.lon
-
-    if lat is None or lon is None:
-        if config.zip is not None and config.country is not None:
-            print(f"performing geocoding lookup for {config.zip}, {config.country}")
-            display.display_text(
-                DisplayController.RENDER_FLAG_FLUSH,
-                FontSize.SMALL,
-                f"Looking up location..."
-            )
-            try:
-                lat, lon = lookup_geocoding(config.zip, config.country, config.openweathermap_key)
-            except Exception as e:
-                print(f"error during geocoding lookup: {e}")
-                display.display_text(
-                    DisplayController.RENDER_FLAG_FLUSH,
-                    FontSize.SMALL,
-                    "Failed to lookup location",
-                    f"Cause: {e}"
-                )
-                display.deep_sleep()
-                disconnect(wlan)
-                utime.sleep(300)
-                machine.reset()
-        else:
-            print(f"error: must specify either lat/lon or zip/country in config.txt")
-            display.display_text(
-                DisplayController.RENDER_FLAG_FLUSH,
-                FontSize.SMALL,
-                "Config error:",
-                "Must specify lat/lon",
-                "or zip/country"
-            )
-            display.deep_sleep()
-            disconnect(wlan)
-            utime.sleep(300)
-            machine.reset()
+    lat, lon = determine_location(config, display, wlan)
 
     try:
         current, daily = fetch_weather(display, lat, lon, config.openweathermap_key)

--- a/weather.py
+++ b/weather.py
@@ -81,28 +81,6 @@ def get_img_for_title(title: str) -> str:
     return img_path
 
 
-def lookup_geocoding(zip_code: str, country: str, openweathermap_key: str) -> tuple[str, str]:
-    """
-    Looks up the latitude and longitude for a given zip/postcode and country code
-    using the OpenWeatherMap Geocoding API.
-    :param zip_code: the zip/postcode
-    :param country: the country code (e.g. 'GB', 'US')
-    :param openweathermap_key: the OpenWeatherMap API key
-    :return: tuple of (lat, lon) as strings
-    """
-    url = f"http://api.openweathermap.org/geo/1.0/zip?zip={zip_code},{country}&appid={openweathermap_key}"
-    print(f"geocoding lookup: {url}")
-    r = requests.get(url)
-    resp: dict = r.json()
-    r.close()
-
-    lat = str(resp['lat'])
-    lon = str(resp['lon'])
-    print(f"geocoding result: {resp['name']} ({resp['country']}) -> lat={lat}, lon={lon}")
-
-    return lat, lon
-
-
 def fetch_weather(display: DisplayController, lat: str, lon: str, openweathermap_key: str) -> tuple[Weather, Weather]:
     """
     Fetches the current weather from OpenWeatherMap and returns a tuple

--- a/weather.py
+++ b/weather.py
@@ -81,6 +81,28 @@ def get_img_for_title(title: str) -> str:
     return img_path
 
 
+def lookup_geocoding(zip_code: str, country: str, openweathermap_key: str) -> tuple[str, str]:
+    """
+    Looks up the latitude and longitude for a given zip/postcode and country code
+    using the OpenWeatherMap Geocoding API.
+    :param zip_code: the zip/postcode
+    :param country: the country code (e.g. 'GB', 'US')
+    :param openweathermap_key: the OpenWeatherMap API key
+    :return: tuple of (lat, lon) as strings
+    """
+    url = f"http://api.openweathermap.org/geo/1.0/zip?zip={zip_code},{country}&appid={openweathermap_key}"
+    print(f"geocoding lookup: {url}")
+    r = requests.get(url)
+    resp: dict = r.json()
+    r.close()
+
+    lat = str(resp['lat'])
+    lon = str(resp['lon'])
+    print(f"geocoding result: {resp['name']} ({resp['country']}) -> lat={lat}, lon={lon}")
+
+    return lat, lon
+
+
 def fetch_weather(display: DisplayController, lat: str, lon: str, openweathermap_key: str) -> tuple[Weather, Weather]:
     """
     Fetches the current weather from OpenWeatherMap and returns a tuple


### PR DESCRIPTION
Users can now specify location using either:
- Direct lat/lon coordinates (existing method)
- Zip/postcode and country code (new method)

When zip/country are provided, the system automatically calls the OpenWeatherMap Geocoding API to convert them to lat/lon before fetching weather data.

Changes:
- Added lookup_geocoding() function in weather.py to call geocoding API
- Updated Config class to support optional zip and country fields
- Modified main.py fetch() to handle geocoding lookup when needed
- Updated config.txt.example with examples for both location methods
- Updated CLAUDE.md documentation to explain both options

The geocoding API follows OpenWeatherMap's documentation: http://api.openweathermap.org/geo/1.0/zip?zip={code},{country}&appid={key}